### PR TITLE
fix(calavera): Remove sass and styleint from commonjs

### DIFF
--- a/lib/calavera.js
+++ b/lib/calavera.js
@@ -73,9 +73,9 @@ async function fillCatacomb() {
                 );
                 break;
             case 'commonjs':
-                writeFiles(COMMON_WEB.concat(COMMON_JS));
+                writeFiles(COMMON_JS);
                 dependecies = addDependencies(
-                    COMMON_WEB_DEPENDECIES.concat(COMMON_JS_DEPENDECIES),
+                    COMMON_JS_DEPENDECIES,
                     dependecies
                 );
                 break;


### PR DESCRIPTION
Remove sass and stylelint entries from commonjs bundle. This now only adds babeljs

Fix #27